### PR TITLE
feat: expand domain query functionality add get domain details

### DIFF
--- a/src/dmailfi_icp_backend/dmailfi_icp_backend.did
+++ b/src/dmailfi_icp_backend/dmailfi_icp_backend.did
@@ -16,4 +16,5 @@ service : {
   greet : (text) -> (text) query;
   lookup_domain_name : (text) -> (Result) query;
   upgrade_all_dmail_canisters : () -> (Result_1);
-}
+  get_domain_details : (text) -> (text) query;
+};

--- a/src/dmailfi_icp_backend/src/lib.rs
+++ b/src/dmailfi_icp_backend/src/lib.rs
@@ -109,6 +109,12 @@ async fn upgrade_all_dmail_canisters() -> Result<(), RegistryError> {
     Ok(())
 }
 
+#[query]
+#[candid_method(query)]
+async fn get_domain_details(domain_name: DOMAIN_NAME) -> Result<std::string::String, RegistryError> {
+    ledger::with(|ledger| ledger.get_domain_details(domain_name))
+}
+
 fn is_custodian() -> Result<(), std::string::String> {
     ledger::with(|ledger|{
         ledger.is_custodian(caller().to_text())

--- a/src/dmailfi_icp_backend/src/types.rs
+++ b/src/dmailfi_icp_backend/src/types.rs
@@ -46,5 +46,17 @@ impl Ledger {
     pub fn get_all_domain_canisters(&self) -> Vec<String> {
         self.domains.values().cloned().collect()
     }
+    pub fn get_domain_details(&self, domain_name : DOMAIN_NAME) -> Result<String, RegistryError> {
+        match self.domains.get(&domain_name){
+            Some(details) => {
+                let details_str = format!(
+                    "Domain: {} is managed by canister: {}",
+                    domain_name,
+                    details
+                );
+                Ok(details_str)
+            }
+            None => Err(RegistryError::NotFound)
+        }
+    }
 }
-


### PR DESCRIPTION
- Added `get_domain_details` function to retrieve detailed information about a specific domain.
- Updated `dmailfi_icp_backend.did` to include the new query methods.
- Updated `lib.rs` to implement the new query methods.
- Updated `Ledger` struct to support the new query methods.